### PR TITLE
feat: 診断API連携とCORS対応を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ out/
 
 # Env
 .env
+.env*.local

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,6 +7,28 @@ import (
 	"net/http"
 )
 
+// CORSミドルウェア
+// 開発環境では "*" で全てのオリジンを許可しているが、
+// 本番環境では特定のオリジンのみ許可すべき
+// 例: w.Header().Set("Access-Control-Allow-Origin", "https://your-frontend-domain.com")
+func corsMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// CORSヘッダーを設定
+		w.Header().Set("Access-Control-Allow-Origin", "*") // 開発環境用：本番では特定ドメインに制限すること
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		// プリフライトリクエストの処理
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// 次のハンドラを実行
+		next(w, r)
+	}
+}
+
 func main() {
 	// サービス初期化
 	diagnosisService := service.NewDiagnosisService()
@@ -15,9 +37,9 @@ func main() {
 	healthHandler := handler.NewHealthHandler()
 	diagnosisHandler := handler.NewDiagnosisHandler(diagnosisService)
 
-	// ルーティング設定
-	http.HandleFunc("/health", healthHandler.Handle)
-	http.HandleFunc("/diagnosis", diagnosisHandler.Handle)
+	// ルーティング設定（CORSミドルウェアを適用）
+	http.HandleFunc("/health", corsMiddleware(healthHandler.Handle))
+	http.HandleFunc("/diagnosis", corsMiddleware(diagnosisHandler.Handle))
 
 	// サーバー起動
 	log.Println("Server starting on :8080")

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# バックエンドAPIのベースURL
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080

--- a/frontend/app/result/page.tsx
+++ b/frontend/app/result/page.tsx
@@ -1,24 +1,39 @@
 'use client';
 
 import { useState } from 'react';
-import { STORAGE_KEY, DiagnosticAnswers } from '@/types/diagnosis';
+import { useRouter } from 'next/navigation';
+import { STORAGE_KEY, RESULT_STORAGE_KEY, DiagnosisResponse } from '@/types/diagnosis';
+import Button from '@/components/common/Button';
+import LayoutContainer from '@/components/common/LayoutContainer';
 
 export default function ResultPage() {
-  const [answers] = useState<DiagnosticAnswers | null>(() => {
+  const router = useRouter();
+  
+  // sessionStorageから回答データをクリア（初期化時に実行）
+  useState(() => {
+    if (typeof window === 'undefined') return;
+    
+    const savedAnswers = sessionStorage.getItem(STORAGE_KEY);
+    if (savedAnswers) {
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+  });
+
+  const [result] = useState<DiagnosisResponse | null>(() => {
     // サーバーサイドではnullを返す
     if (typeof window === 'undefined') return null;
 
-    // sessionStorageから回答データを読み取る
-    const savedAnswers = sessionStorage.getItem(STORAGE_KEY);
+    // sessionStorageから診断結果を読み取る
+    const savedResult = sessionStorage.getItem(RESULT_STORAGE_KEY);
 
-    if (savedAnswers) {
+    if (savedResult) {
       try {
-        const parsedAnswers = JSON.parse(savedAnswers);
+        const parsedResult = JSON.parse(savedResult);
         // 読み取り完了後、sessionStorageをクリア
-        sessionStorage.removeItem(STORAGE_KEY);
-        return parsedAnswers;
+        sessionStorage.removeItem(RESULT_STORAGE_KEY);
+        return parsedResult;
       } catch (error) {
-        console.error('Failed to parse answers:', error);
+        console.error('Failed to parse result:', error);
       }
     }
     return null;
@@ -26,40 +41,72 @@ export default function ResultPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-black py-12 px-4">
-      <div className="max-w-3xl mx-auto">
+      <LayoutContainer>
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
             診断結果
           </h1>
-          <p className="text-gray-600 dark:text-gray-400">
-            （この画面は仮）
-          </p>
-        </div>
-
-        <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-8">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
-            回答データ確認
-          </h2>
-
-          {answers ? (
-            <div className="space-y-2">
-              <p className="text-green-600 dark:text-green-400 font-medium mb-4">
-                ✓ 回答データの読み取りに成功しました
-              </p>
-              <pre className="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-auto text-sm">
-                {JSON.stringify(answers, null, 2)}
-              </pre>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-4">
-                ※ sessionStorageからのデータ読み取り後、自動的にクリアされました
-              </p>
-            </div>
-          ) : (
-            <p className="text-red-600 dark:text-red-400">
-              回答データが見つかりませんでした
+          {result && (
+            <p className="text-gray-600 dark:text-gray-400">
+              仮ページです
             </p>
           )}
         </div>
-      </div>
+
+        {result ? (
+          <div className="space-y-6">
+            {/* スコア表示 */}
+            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-8 text-center">
+              <div className="mb-4">
+                <span className="text-6xl font-bold text-blue-600 dark:text-blue-400">
+                  {result.score}
+                </span>
+                <span className="text-2xl text-gray-500 dark:text-gray-400 ml-2">点</span>
+              </div>
+              <div className="inline-block bg-blue-100 dark:bg-blue-900 px-6 py-2 rounded-full">
+                <span className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+                  ランク {result.rank}
+                </span>
+              </div>
+            </div>
+
+            {/* コメント表示 */}
+            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-8">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                診断コメント
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+                {result.comment}
+              </p>
+            </div>
+
+            {/* もう一度診断するボタン */}
+            <div className="flex justify-center pt-4">
+              <Button
+                onClick={() => router.push('/diagnostic')}
+                variant="secondary"
+                size="lg"
+              >
+                もう一度診断する
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-8">
+            <p className="text-red-600 dark:text-red-400 text-center">
+              診断結果が見つかりませんでした。診断画面からやり直してください。
+            </p>
+            <div className="flex justify-center mt-6">
+              <Button
+                onClick={() => router.push('/diagnostic')}
+                size="lg"
+              >
+                診断画面へ戻る
+              </Button>
+            </div>
+          </div>
+        )}
+      </LayoutContainer>
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,25 @@
+import { DiagnosisRequest, DiagnosisResponse } from '@/types/diagnosis';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+
+/**
+ * 診断APIを呼び出す
+ * @param answers 診断の回答データ（q1〜q10）
+ * @returns 診断結果（score, rank, comment）
+ */
+export async function submitDiagnosis(answers: DiagnosisRequest['answers']): Promise<DiagnosisResponse> {
+  const response = await fetch(`${API_BASE_URL}/diagnosis`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ answers }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data: DiagnosisResponse = await response.json();
+  return data;
+}

--- a/frontend/types/diagnosis.ts
+++ b/frontend/types/diagnosis.ts
@@ -7,5 +7,29 @@ export interface Question {
 //診断回答の型定義
 export type DiagnosticAnswers = Record<string, number>;
 
+//診断APIリクエストの型定義
+export interface DiagnosisRequest {
+  answers: {
+    q1: number;
+    q2: number;
+    q3: number;
+    q4: number;
+    q5: number;
+    q6: number;
+    q7: number;
+    q8: number;
+    q9: number;
+    q10: number;
+  };
+}
+
+//診断APIレスポンスの型定義
+export interface DiagnosisResponse {
+  score: number;
+  rank: string;
+  comment: string;
+}
+
 //sessionStorageのキー名
 export const STORAGE_KEY = 'uma-chi-diagnostic-answers';
+export const RESULT_STORAGE_KEY = 'uma-chi-diagnosis-result';


### PR DESCRIPTION
- バックエンドにCORSミドルウェアを追加し、フロントエンドからのリクエストを許可
- フロントエンドに診断API呼び出し機能を実装 (lib/api.ts)
- 診断画面からAPI送信を実装し、結果をsessionStorageに保存
- 結果画面でバックエンドから取得した診断結果を表示
- API連携用の型定義を追加 (DiagnosisRequest, DiagnosisResponse)
- 環境変数でAPIベースURLを設定可能に (.env.local)